### PR TITLE
Fix downloader file name

### DIFF
--- a/CommonUpdater/Downloader.cs
+++ b/CommonUpdater/Downloader.cs
@@ -15,7 +15,7 @@ namespace CommonUpdater
     {
         public const string ApiUrl = "https://ci.appveyor.com/api";
         public static string ProjectUrl = $"{ApiUrl}/projects/gavazquez/lunamultiplayer";
-        public const string FileName = "LunaMultiplayer-Debug.zip";
+        public const string FileName = "LunaMultiplayer-Client-Debug.zip";
         public static string FolderToDecompress = Path.Combine(Path.GetTempPath(), "LMP");
 
         public static void DownloadAndReplaceFiles(ProductToDownload product)


### PR DESCRIPTION
I have not tested this, however the downloader doesn't seem to be working for me:  
![image](https://user-images.githubusercontent.com/293107/124458010-0fe3a000-ddbf-11eb-9755-aae4550282fb.png)

`https://ci.appveyor.com/api/projects/gavazquez/lunamultiplayer/` returns 404  

`https://ci.appveyor.com/api/buildjobs/srqqfsmscc3drkso/artifacts/LunaMultiplayer-Client-Debug.zip` provides a .zip.  

I am **assuming** this is the issue here and this is the fix for it.  

#5 wanted to have this configurable `Debug`/`Release`.